### PR TITLE
Allow creating display3D samples.

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -16,5 +16,6 @@
 	<sample path="features/media" />
 	<sample path="features/events" />
 	<sample path="features/display" />
+	<sample path="features/display3D" />
 	
 </extension>


### PR DESCRIPTION
Without this, commands like `openfl create HelloTriangle` won't work.