### PR TITLE
always rescaling

### DIFF
--- a/haxelib/demos/PiratePig/Source/piratepig/PiratePigGame.hx
+++ b/haxelib/demos/PiratePig/Source/piratepig/PiratePigGame.hx
@@ -475,25 +475,21 @@ class PiratePigGame extends Sprite {
 		var currentWidth = width;
 		var currentHeight = height;
 		
-		if (currentWidth > maxWidth || currentHeight > maxHeight) {
+    var maxScaleX = maxWidth / currentWidth;
+    var maxScaleY = maxHeight / currentHeight;
+    
+    if (maxScaleX < maxScaleY) {
+      
+      currentScale = maxScaleX;
+      
+    } else {
+      
+      currentScale = maxScaleY;
+      
+    }
 			
-			var maxScaleX = maxWidth / currentWidth;
-			var maxScaleY = maxHeight / currentHeight;
-			
-			if (maxScaleX < maxScaleY) {
-				
-				currentScale = maxScaleX;
-				
-			} else {
-				
-				currentScale = maxScaleY;
-				
-			}
-			
-			scaleX = currentScale;
-			scaleY = currentScale;
-			
-		}
+    scaleX = currentScale;
+    scaleY = currentScale;
 		
 		x = newWidth / 2 - (currentWidth * currentScale) / 2;
 		


### PR DESCRIPTION
I've been playing around with the Haxelib PiratePig sample on html5 and Android and I think the tiles look better when they always rescale (even when the original size is smaller):

Without resizing when smaller (On an Galaxy Note 4):
Portrait:
![screenshot_2018-06-30-17-12-03](https://user-images.githubusercontent.com/4680342/42127607-ce3c1b94-7c93-11e8-9d17-d83d481a0c30.png)
Landscape:
![screenshot_2018-06-30-17-12-07](https://user-images.githubusercontent.com/4680342/42127610-d6736f38-7c93-11e8-8089-91e495f3ff0f.png)

With resizing when smaller (getting rid of the surrounding `if` statement check on `resize` in `PiratePigGame.hx`:
Portrait:
![screenshot_2018-06-30-17-09-54](https://user-images.githubusercontent.com/4680342/42127627-1e1bdfb4-7c94-11e8-98db-67fa833b9805.png)
Landscape:
![screenshot_2018-06-30-17-09-59](https://user-images.githubusercontent.com/4680342/42127628-23555c8a-7c94-11e8-8811-60c3a17cfd23.png)

This is true on the html5 build as well.

I have also checked the npm versions on the desktop browser and they aren't as pronounced (there's something in the npm samples that seems to initiate the dimensions to 650 * 685 but I couldn't figure out where it was, any ideas?).

If this is happening on other people's devices we can proceed to remove the `if` statement on the npm version as well and then maybe do another check to make sure the grid doesn't overlap too much into the border (as it does in the 'fixed' landscape version).